### PR TITLE
NOT-65 fix add new image button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 /tests/fixtures/email/
+prisma/data.db

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "sveltekit-superforms": "^2.18.0",
         "tslib": "^2.4.1",
         "typescript": "^5.0.0",
-        "typescript-eslint": "^8.0.0",
+        "typescript-eslint": "^8.6.0",
         "unplugin-icons": "^0.18.5",
         "vite": "^5.0.3",
         "vitest": "^1.6.0"
@@ -3566,17 +3566,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.5.0.tgz",
-      "integrity": "sha512-lHS5hvz33iUFQKuPFGheAB84LwcJ60G8vKnEhnfcK1l8kGVLro2SFYW6K0/tj8FUhRJ0VHyg1oAfg50QGbPPHw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.6.0.tgz",
+      "integrity": "sha512-UOaz/wFowmoh2G6Mr9gw60B1mm0MzUtm6Ic8G2yM1Le6gyj5Loi/N+O5mocugRGY+8OeeKmkMmbxNqUCq3B4Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/type-utils": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/type-utils": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3600,16 +3600,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.5.0.tgz",
-      "integrity": "sha512-gF77eNv0Xz2UJg/NbpWJ0kqAm35UMsvZf1GHj8D9MRFTj/V3tAciIWXfmPLsAAF/vUlpWPvUDyH1jjsr0cMVWw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.6.0.tgz",
+      "integrity": "sha512-eQcbCuA2Vmw45iGfcyG4y6rS7BhWfz9MQuk409WD47qMM+bKCGQWXxvoOs1DUp+T7UBMTtRTVT+kXr7Sh4O9Ow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3629,14 +3629,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.5.0.tgz",
-      "integrity": "sha512-06JOQ9Qgj33yvBEx6tpC8ecP9o860rsR22hWMEd12WcTRrfaFgHr2RB/CA/B+7BMhHkXT4chg2MyboGdFGawYg==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.6.0.tgz",
+      "integrity": "sha512-ZuoutoS5y9UOxKvpc/GkvF4cuEmpokda4wRg64JEia27wX+PysIE9q+lzDtlHHgblwUWwo5/Qn+/WyTUvDwBHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0"
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3647,14 +3647,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.5.0.tgz",
-      "integrity": "sha512-N1K8Ix+lUM+cIDhL2uekVn/ZD7TZW+9/rwz8DclQpcQ9rk4sIL5CAlBC0CugWKREmDjBzI/kQqU4wkg46jWLYA==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.6.0.tgz",
+      "integrity": "sha512-dtePl4gsuenXVwC7dVNlb4mGDcKjDT/Ropsk4za/ouMBPplCLyznIaR+W65mvCvsyS97dymoBRrioEXI7k0XIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0",
+        "@typescript-eslint/typescript-estree": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3672,9 +3672,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.5.0.tgz",
-      "integrity": "sha512-qjkormnQS5wF9pjSi6q60bKUHH44j2APxfh9TQRXK8wbYVeDYYdYJGIROL87LGZZ2gz3Rbmjc736qyL8deVtdw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.6.0.tgz",
+      "integrity": "sha512-rojqFZGd4MQxw33SrOy09qIDS8WEldM8JWtKQLAjf/X5mGSeEFh5ixQlxssMNyPslVIk9yzWqXCsV2eFhYrYUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3686,14 +3686,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.5.0.tgz",
-      "integrity": "sha512-vEG2Sf9P8BPQ+d0pxdfndw3xIXaoSjliG0/Ejk7UggByZPKXmJmw3GW5jV2gHNQNawBUyfahoSiCFVov0Ruf7Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.6.0.tgz",
+      "integrity": "sha512-MOVAzsKJIPIlLK239l5s06YXjNqpKTVhBVDnqUumQJja5+Y94V3+4VUFRA0G60y2jNnTVwRCkhyGQpavfsbq/g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/visitor-keys": "8.5.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/visitor-keys": "8.6.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -3741,16 +3741,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.5.0.tgz",
-      "integrity": "sha512-6yyGYVL0e+VzGYp60wvkBHiqDWOpT63pdMV2CVG4LVDd5uR6q1qQN/7LafBZtAtNIn/mqXjsSeS5ggv/P0iECw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.6.0.tgz",
+      "integrity": "sha512-eNp9cWnYf36NaOVjkEUznf6fEgVy1TWpE0o52e4wtojjBx7D1UV2WAWGzR+8Y5lVFtpMLPwNbC67T83DWSph4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.5.0",
-        "@typescript-eslint/types": "8.5.0",
-        "@typescript-eslint/typescript-estree": "8.5.0"
+        "@typescript-eslint/scope-manager": "8.6.0",
+        "@typescript-eslint/types": "8.6.0",
+        "@typescript-eslint/typescript-estree": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3764,13 +3764,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.5.0.tgz",
-      "integrity": "sha512-yTPqMnbAZJNy2Xq2XU8AdtOW9tJIr+UQb64aXB9f3B1498Zx9JorVgFJcZpEc9UBuCCrdzKID2RGAMkYcDtZOw==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.6.0.tgz",
+      "integrity": "sha512-wapVFfZg9H0qOYh4grNVQiMklJGluQrOUiOhYRrQWhx7BY/+I1IYb8BczWNbbUpO+pqy0rDciv3lQH5E1bCLrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.5.0",
+        "@typescript-eslint/types": "8.6.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -10264,15 +10264,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.5.0.tgz",
-      "integrity": "sha512-uD+XxEoSIvqtm4KE97etm32Tn5MfaZWgWfMMREStLxR6JzvHkc2Tkj7zhTEK5XmtpTmKHNnG8Sot6qDfhHtR1Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.6.0.tgz",
+      "integrity": "sha512-eEhhlxCEpCd4helh3AO1hk0UP2MvbRi9CtIAJTVPQjuSXOOO2jsEacNi4UdcJzZJbeuVg1gMhtZ8UYb+NFYPrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.5.0",
-        "@typescript-eslint/parser": "8.5.0",
-        "@typescript-eslint/utils": "8.5.0"
+        "@typescript-eslint/eslint-plugin": "8.6.0",
+        "@typescript-eslint/parser": "8.6.0",
+        "@typescript-eslint/utils": "8.6.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "sveltekit-superforms": "^2.18.0",
     "tslib": "^2.4.1",
     "typescript": "^5.0.0",
-    "typescript-eslint": "^8.0.0",
+    "typescript-eslint": "^8.6.0",
     "unplugin-icons": "^0.18.5",
     "vite": "^5.0.3",
     "vitest": "^1.6.0"

--- a/src/lib/components/EditNote/EditNote.svelte
+++ b/src/lib/components/EditNote/EditNote.svelte
@@ -1,10 +1,6 @@
 <!-- TODO: This is quite the component, will need a clean up at some stage NOT-63 -->
 <script lang="ts">
-	import {
-		type SuperValidated,
-		type Infer,
-		superForm,
-	} from 'sveltekit-superforms'
+	import { superForm } from 'sveltekit-superforms'
 	import { zodClient } from 'sveltekit-superforms/adapters'
 	import {
 		Input,
@@ -16,15 +12,18 @@
 		Cross,
 		Plus,
 	} from '$lib/components'
-	import type { ImageFieldset } from './types.editNote'
+	import type { EditNoteProps } from './types.editNote'
 	import { NoteEditorSchema } from '$lib/schemas'
 	import { generateCopy } from './editNote.helpers'
 	import { idTestId, imageListTestId } from './consts.editNote'
 	import InfoBar from './InfoBar.svelte'
 
-	export let data: SuperValidated<Infer<typeof NoteEditorSchema>>
-	export let images: Array<ImageFieldset> = []
-	export let action: string
+	let { data, action, images }: EditNoteProps = $props()
+	let imageList = $state(
+		images?.length
+			? images
+			: [{ id: undefined, file: undefined, altText: undefined }],
+	)
 
 	const { form, errors, enhance, formId, constraints, delayed, timeout } =
 		superForm(data, {
@@ -34,10 +33,6 @@
 		$form.id,
 		$form.title,
 	)
-
-	$: imageList = images.length
-		? images
-		: [{ id: undefined, file: undefined, altText: undefined }]
 
 	function addEmptyImage() {
 		imageList = [
@@ -93,8 +88,9 @@
 					class="remove-image-button"
 					name="id"
 					value={image.id ?? index}
-					on:click|preventDefault={() =>
-						(imageList = imageList.filter((_, i) => i !== index))}
+					onclick={() => {
+						imageList = imageList.filter((_, i) => i !== index)
+					}}
 				>
 					<span aria-hidden="true">
 						<Cross />
@@ -106,7 +102,7 @@
 		{/each}
 	</ul>
 	<!-- TODO: AddEmptyImage is not working 🐛 NOT-65 -->
-	<Button variant="secondary" type="button" on:click={addEmptyImage}>
+	<Button variant="secondary" type="button" onclick={addEmptyImage}>
 		<Plus />
 		Add another image
 	</Button>

--- a/src/lib/components/EditNote/types.editNote.ts
+++ b/src/lib/components/EditNote/types.editNote.ts
@@ -1,5 +1,10 @@
-import type { ImageFieldsetListSchema, ImageFieldsetSchema } from '$lib/schemas'
+import type {
+	ImageFieldsetListSchema,
+	ImageFieldsetSchema,
+	NoteEditorSchema,
+} from '$lib/schemas'
 import type { Readable, Writable } from 'svelte/store'
+import type { Infer, SuperValidated } from 'sveltekit-superforms'
 import { z } from 'zod'
 
 export type ImageFieldsetList = z.infer<typeof ImageFieldsetListSchema>
@@ -11,4 +16,10 @@ export type InfoBarProps = {
 	submitDelayedReason: string
 	delayed: Readable<boolean>
 	timeout: Readable<boolean>
+}
+
+export type EditNoteProps = {
+	data: SuperValidated<Infer<typeof NoteEditorSchema>>
+	action: string
+	images?: Array<ImageFieldset>
 }

--- a/src/lib/components/FormElements/Input/types.input.ts
+++ b/src/lib/components/FormElements/Input/types.input.ts
@@ -14,7 +14,7 @@ export type InputProps = {
 	fluid?: boolean
 	hidden?: boolean
 	onchange?: () => void
-	type?: 'text' | 'password' | 'search' | 'hidden' | null
+	type?: 'text' | 'password' | 'search' | 'hidden' | 'email' | null
 	oninput?: (
 		event: Event & { currentTarget: EventTarget & HTMLInputElement },
 	) => void

--- a/src/lib/components/ImageEditor/ImageEditor.svelte
+++ b/src/lib/components/ImageEditor/ImageEditor.svelte
@@ -1,39 +1,24 @@
 <script lang="ts">
 	import { Input, Plus } from '$lib/components'
-	import { getNoteImgSrc } from '$lib/utils/misc'
-	import type { ImageFieldset } from '$lib/components/EditNote/types.editNote'
+	import { createState } from './helpers.imageEditor.svelte'
+	import type { ImageEditorProps } from './types.imageEditor'
 
-	export let image: ImageFieldset | undefined
-	export let index: number
-
-	let previewImage: string | null = image?.id ? getNoteImgSrc(image?.id) : null
-	const existingImage = Boolean(image?.id)
+	let { image, index }: ImageEditorProps = $props()
+	const helperState = createState(image)
 
 	const fileGroupPrefix = `note-editor-images[${index}]`
-	function handleFileChange(event: Event) {
-		const file = (event.target as HTMLInputElement).files?.[0]
-		if (file) {
-			const reader = new FileReader()
-			reader.onload = () => {
-				previewImage = reader.result as string
-			}
-			reader.readAsDataURL(file)
-		} else {
-			previewImage = null
-		}
-	}
 </script>
 
 <fieldset id={fileGroupPrefix} class="container">
 	<legend class="sr-only">Select an image to upload</legend>
 
-	<!-- TODO: fix focus for file input -->
+	<!-- TODO: NOT-71 fix focus for file input -->
 	<div class="file-input-container">
 		<label class="file-label">
-			{#if previewImage}
+			{#if helperState.state.previewImage}
 				<img
 					class="preview-image absolute"
-					src={previewImage}
+					src={helperState.state.previewImage}
 					alt={image?.altText ?? ''}
 				/>
 			{:else}
@@ -42,7 +27,7 @@
 				</button>
 			{/if}
 			<input
-				on:change={handleFileChange}
+				onchange={helperState.handleFileChange}
 				id="{fileGroupPrefix}.file"
 				name="images[{index}].file"
 				value={image?.file}
@@ -53,7 +38,7 @@
 			/>
 		</label>
 		<!-- <ValidationErrors {errors} errorId={fileId} /> -->
-		{#if existingImage && image?.id}
+		{#if helperState.existingImage && image?.id}
 			<input
 				type="hidden"
 				id="{fileGroupPrefix}.id"

--- a/src/lib/components/ImageEditor/helpers.imageEditor.svelte.ts
+++ b/src/lib/components/ImageEditor/helpers.imageEditor.svelte.ts
@@ -1,0 +1,32 @@
+import { getNoteImgSrc } from '$lib/utils/misc'
+import type { ImageFieldset } from '../EditNote/types.editNote'
+
+export function createState(initialValue: ImageFieldset | undefined) {
+	let state: { previewImage: string | null } = $state({
+		previewImage: initialValue?.id ? getNoteImgSrc(initialValue?.id) : null,
+	})
+	let existingImage = $derived(
+		initialValue?.id ? getNoteImgSrc(initialValue?.id) : null,
+	)
+
+	function handleFileChange(event: Event) {
+		const file = (event.target as HTMLInputElement).files?.[0]
+		if (file) {
+			const reader = new FileReader()
+			reader.onload = () => {
+				state.previewImage = reader.result as string
+			}
+			reader.readAsDataURL(file)
+		} else {
+			state.previewImage = null
+		}
+	}
+
+	return {
+		state,
+		get existingImage() {
+			return existingImage
+		},
+		handleFileChange,
+	}
+}

--- a/src/lib/components/ImageEditor/types.imageEditor.ts
+++ b/src/lib/components/ImageEditor/types.imageEditor.ts
@@ -1,0 +1,6 @@
+import type { ImageFieldset } from '../EditNote/types.editNote'
+
+export type ImageEditorProps = {
+	image: ImageFieldset | undefined
+	index: number
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -214,7 +214,7 @@ export const LoginFormSchema = z.object({
 })
 
 export const SignupFormSchema = z.object({
-	email: z.string(),
+	email: z.string().email(),
 })
 
 export const ResetPasswordSchema = PasswordAndConfirmPasswordSchema

--- a/src/lib/utils/mocks.ts
+++ b/src/lib/utils/mocks.ts
@@ -1,10 +1,8 @@
 import path from 'node:path'
-import { fileURLToPath } from 'node:url'
 import fsExtra from 'fs-extra'
 import { z } from 'zod'
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url))
-const fixturesDirPath = path.join(__dirname, '/tests/fixtures', 'fixtures')
+const fixturesDirPath = path.join('tests', 'fixtures')
 
 // Defines the schema for an email object using zod
 

--- a/src/routes/(auth)/signup/+page.svelte
+++ b/src/routes/(auth)/signup/+page.svelte
@@ -30,7 +30,7 @@
 			bind:value={$form.email}
 			errors={$errors.email}
 			constraints={$constraints.email}
-			type="text"
+			type="email"
 		/>
 	</FormGroup>
 	<Button fluid type="submit" variant="secondary">Submit</Button>

--- a/src/routes/settings/profile/change-email/+page.svelte
+++ b/src/routes/settings/profile/change-email/+page.svelte
@@ -27,7 +27,7 @@
 		<Input
 			label="New Email"
 			name="email"
-			type="text"
+			type="email"
 			bind:value={$form.email}
 			errors={$errors.email}
 			constraints={$constraints.email}

--- a/src/routes/users/[username]/notes/[noteId]/edit/+page.svelte
+++ b/src/routes/users/[username]/notes/[noteId]/edit/+page.svelte
@@ -2,7 +2,7 @@
 	import { EditNote } from '$lib/components'
 	import { page } from '$app/stores'
 
-	export let data
+	let { data } = $props()
 	const action = `/users/${$page.params.username}/notes/${$page.params.noteId}/edit?/newOrUpdate`
 </script>
 

--- a/src/routes/users/[username]/notes/new-note/+page.svelte
+++ b/src/routes/users/[username]/notes/new-note/+page.svelte
@@ -2,7 +2,7 @@
 	import { page } from '$app/stores'
 	import { EditNote } from '$lib/components'
 
-	export let data
+	let { data } = $props()
 
 	const action = `/users/${$page.params.username}/notes/new-note?/newOrUpdate`
 </script>


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
- Fixed add new image button in edit/new notes
- Converted some files to svelte 5
- Image editor helper function for state
## Test Plan

<!-- What steps need to be taken to verify this works as expected? -->
- Edit or create a new note
- Click the add new image button
- Observe a new empty image is created
## Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Mobile sizes checked

## Screenshots
![image](https://github.com/user-attachments/assets/069f935b-4a83-4cc6-ad08-3e93823eb66f)
![image](https://github.com/user-attachments/assets/c3eeadca-f468-4362-9dd2-3d6f1050191b)

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
