### PR TITLE
NOT-60 fixed up note action bar styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ node_modules
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 /tests/fixtures/email/
-prisma/data.db
+/prisma/data.db

--- a/src/lib/components/NoteInfoBar/NoteInfoBar.svelte
+++ b/src/lib/components/NoteInfoBar/NoteInfoBar.svelte
@@ -4,18 +4,18 @@
 
 <style>
 	.info-bar {
-		grid-column: 1 / 4;
-		grid-row: 2 / span 1;
+		position: absolute;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
 		bottom: var(--space-m);
-		left: var(--space-xl);
-		right: var(--space-xl);
+		left: var(--space-m);
+		right: var(--space-m);
 		padding: var(--space-s);
 		border-radius: var(--border-radius);
 		backdrop-filter: blur(3px);
 		background: hsl(0, 0%, 100%, 0.4);
 		border: 2px solid white;
+		box-shadow: var(--shadow-base);
 	}
 </style>

--- a/src/lib/styles/app.css
+++ b/src/lib/styles/app.css
@@ -76,6 +76,12 @@
 	--color-cream-95: var(--base-cream), 95%;
 	--color-cream-98: var(--base-cream), 98%;
 
+	--shadow-color-base: 30deg 5% 79%;
+	--shadow-base: 0px 0.7px 1px hsl(var(--shadow-color-base) / 0.01),
+		0px 2.7px 4px hsl(var(--shadow-color-base) / 0.09),
+		0px 5.3px 7.9px -0.1px hsl(var(--shadow-color-base) / 0.18),
+		0px 10.7px 15.9px -0.1px hsl(var(--shadow-color-base) / 0.26);
+
 	/* Grey */
 	--base-grey: 28, 10%;
 	--color-grey-10: hsl(var(--base-grey), 10%);
@@ -226,6 +232,12 @@ ol[role='list'] {
 /* Set core root defaults */
 html:focus-within {
 	scroll-behavior: smooth;
+}
+
+body,
+html {
+	height: 100vh;
+	overflow: hidden;
 }
 
 /* Set core body defaults */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -21,13 +21,12 @@
 
 <div class="content">
 	<Toast toast={data.toast} />
-
-	<div class="content-body">
-		{@render children()}
-	</div>
 	<header>
 		<Navbar user={data.user} />
 	</header>
+	<div class="content-body">
+		{@render children()}
+	</div>
 	<footer>I'm the 🦶er</footer>
 </div>
 

--- a/src/routes/users/[username]/notes/+layout.svelte
+++ b/src/routes/users/[username]/notes/+layout.svelte
@@ -73,16 +73,14 @@
 	}
 
 	.main {
+		position: relative;
 		grid-area: main;
-		display: grid;
-		grid-template-columns: var(--space-m) 1fr var(--space-m);
-		grid-template-rows: 1fr auto;
-		padding: var(--space-m);
+		padding: var(--space-xl);
 		background: var(--palette-base-light);
 		border-radius: 0 var(--border-radius) var(--border-radius) 0;
 		border: 4px solid var(--palette-base-medium);
 		border-left: none;
-		overflow: auto;
+		overflow: hidden;
 
 		@media (--below-med) {
 			border: none;

--- a/src/routes/users/[username]/notes/[noteId]/+page.svelte
+++ b/src/routes/users/[username]/notes/[noteId]/+page.svelte
@@ -55,13 +55,12 @@
 
 <style>
 	.article {
-		grid-column: 2 / 3;
-		grid-row: 1 / span 2;
 		display: flex;
 		flex-direction: column;
 		gap: var(--space-2xs);
-		overflow: auto;
-		margin-bottom: var(--space-3xl);
+		padding-bottom: var(--space-xl);
+		height: 100%;
+		overflow-y: auto;
 	}
 
 	.heading {


### PR DESCRIPTION
<!-- Summary: Put your summary here -->
- Fixed Notes action bar styling

## Test Plan
- Head to user > notes
- Make sure a note exists that extends beyond the fold of the page
- The action bar now sits on the bottom and when you get to the bottom of a note, the action bar doesn't cover the text
<!-- What steps need to be taken to verify this works as expected? -->

## Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Mobile sizes checked

## Screenshots
![image](https://github.com/user-attachments/assets/f980c0b4-250a-4f27-804b-24a4943899bb)
![image](https://github.com/user-attachments/assets/a1221668-893a-4e4d-8808-ec0d4c56e909)
![image](https://github.com/user-attachments/assets/64aec552-43d0-4b66-a0f5-55e9f4b99452)

<!-- If what you're changing is within the app, please show before/after.
You can provide a video as well if that makes more sense -->
